### PR TITLE
Corrige página desfigurando em caso de erro

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,7 @@ require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!
+
+ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
+  html_tag.html_safe
+end


### PR DESCRIPTION
Tentando entender porque a página de "Adicionar produto" desfigurava quando acontecia algum erro, descobri que é porque o Rails criava uma "div" que indicava os fields com erro. Nós não estamos utilizando essa div para nada e ela inclusive interfere na página de adicionar produtos, e por isso criei esse PR para remover esse comportamento.

https://coderwall.com/p/s-zwrg/remove-rails-field_with_errors-wrapper